### PR TITLE
Add Jest testing setup and sample tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # bsccpsydemo1
 醫療預約系統測試
+
+## Running Tests
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Run the test suite:
+   ```bash
+   npm test
+   ```

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+export default {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ]
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "bsccpsydemo1",
+  "version": "1.0.0",
+  "description": "醫療預約系統測試",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.22.5",
+    "@babel/preset-react": "^7.22.5",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "babel-jest": "^29.5.0",
+    "jest": "^29.5.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"]
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import useLocalStorage from './useLocalStorage.js';
+
+function App() {
+  const [value, setValue] = useLocalStorage('app-test', '');
+
+  return (
+    <div>
+      <input
+        placeholder="test"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+      />
+    </div>
+  );
+}
+
+export default App;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import App from './App.jsx';
+
+test('renders input element', () => {
+  render(<App />);
+  expect(screen.getByPlaceholderText(/test/i)).toBeInTheDocument();
+});

--- a/src/useLocalStorage.js
+++ b/src/useLocalStorage.js
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+export function useLocalStorage(key, initialValue) {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      return initialValue;
+    }
+  });
+
+  const setValue = value => {
+    try {
+      setStoredValue(value);
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return [storedValue, setValue];
+}
+export default useLocalStorage;

--- a/src/useLocalStorage.test.js
+++ b/src/useLocalStorage.test.js
@@ -1,0 +1,23 @@
+import { renderHook, act } from '@testing-library/react';
+import { useLocalStorage } from './useLocalStorage.js';
+
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test('loads initial value from localStorage', () => {
+    window.localStorage.setItem('key', JSON.stringify('stored'));
+    const { result } = renderHook(() => useLocalStorage('key', 'init'));
+    expect(result.current[0]).toBe('stored');
+  });
+
+  test('persists value to localStorage', () => {
+    const { result } = renderHook(() => useLocalStorage('key', 'init'));
+    act(() => {
+      result.current[1]('new');
+    });
+    expect(window.localStorage.getItem('key')).toBe(JSON.stringify('new'));
+    expect(result.current[0]).toBe('new');
+  });
+});


### PR DESCRIPTION
## Summary
- initialize npm package with Jest and React Testing Library
- implement a `useLocalStorage` hook and an example `App` component
- add unit tests for the hook and the component
- provide Babel and Jest configs
- update README with instructions for running tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ef4acb7e083219a939ef2c572509c