### PR TITLE
Fix Chart.js cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1128,6 +1128,7 @@
                 if (chartRef.current) {
                     if (chartInstanceRef.current) {
                         chartInstanceRef.current.destroy();
+                        chartInstanceRef.current = null;
                     }
                     const ctx = chartRef.current.getContext('2d');
                     
@@ -1178,6 +1179,7 @@
                 if (pieChartRef.current) {
                     if (pieChartInstanceRef.current) {
                         pieChartInstanceRef.current.destroy();
+                        pieChartInstanceRef.current = null;
                     }
                     const ctx = pieChartRef.current.getContext('2d');
                     
@@ -1213,8 +1215,14 @@
                 }
 
                 return () => {
-                    if (chartInstanceRef.current) chartInstanceRef.current.destroy();
-                    if (pieChartInstanceRef.current) pieChartInstanceRef.current.destroy();
+                    if (chartInstanceRef.current) {
+                        chartInstanceRef.current.destroy();
+                        chartInstanceRef.current = null;
+                    }
+                    if (pieChartInstanceRef.current) {
+                        pieChartInstanceRef.current.destroy();
+                        pieChartInstanceRef.current = null;
+                    }
                 };
             }, [clients, bookings]);
 


### PR DESCRIPTION
## Summary
- reset Chart refs after destroying existing charts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684ef4a690088321989d5b3b5e41c97f